### PR TITLE
updating the coupling between -c, memory and scratch for issue 122

### DIFF
--- a/source/Pages/compute/prepare_workloads.rst
+++ b/source/Pages/compute/prepare_workloads.rst
@@ -56,18 +56,55 @@ SBATCH directive      Functionality         Usage example
 ``-p <partition>``    partition selection   ``#SBATCH -p infinite`` (the job will run max for 720 hours)
 ==================    ===================   =================
 
-Some notes:
 
-* For regular jobs we advise to always only use 1 node per job script i.e., ``-N 1``. If you need multi-node job execution, consider better an HPC facility.
-* On Spider we provide **8 GB RAM per core**.
+.. _spider-cluster-resources
 
-  * This means that your memory requirements can be specified via the number of cores *without* an extra directive for memory
-  * For example, by specifying ``-c 4`` you request 4 cores and 32 GB RAM
+======================
+Spider cluster resources
+======================
 
-* We have configured two partitions on Spider as shown in the table above:
+.. sinfo
+.. show node info
+
+Spider users can check the availability of Spider resources by typing ``sinfo`` on the command line of the Spider login node. This shows the available partitions (job queues) and the worker nodes assigned to these partitions. Technical information about the individual worker nodes can obtained by typing ``scontrol show node``. Similarly the current state of the job queue is obtained by typing ``squeue``.  
+
+
+.. _slurm-cpu-cores
+
+======================
+Compute resources per requested CPU core
+======================
+.. the '-c' option is -c, --cpus-per-task=<ncpus> (https://slurm.schedmd.com/sbatch.html) 
+
+On Spider we provision compute resources, in terms of RAM memory and local scratch, per requested number of CPU cores to Slurm. For every Slurm job we provide **8 GB RAM and 80 GB scratch space per requested CPU core**. 
+
+All jobs on Spider that require more than 1 cpu, 8 GB RAM and/or 80 GB of local scratch space must specify their requirements via the ``-c`` option. For example, by specifying ``-c 4`` you request 4 cores, 32 GB RAM and 320 GB of local scratch space.
+
+Note that the ``--mem`` option is not supported on Spider and memory requirements must be specified via the coupling to CPU cores as explained above. The scratch space requested by specifying the ``-c`` option only refers to the scratch space locally on the worker node that is assigned to the job. For jobs that use the storage mounted via the shared filesystem, i.e. /project, /catalog and /home, the local scratch space is not directly relevant.
+
+
+.. _slurm-partitions
+
+======================
+Slurm Partitions
+======================
+
+We have configured two partitions (queues) on Spider. These can be requested via the ``-p option``, as shown in the table above:
 
   * If no partition is specified, the jobs will be scheduled on the normal partition  which has a maximum walltime of 120 hours and can run on any worker nodes.
-  * Infinite queues can run only on two worker nodes with a maximum walltime of 720 hours. Please note that you should run on this partition at your own risk. Jobs running on this partition can be killed without warning for system maintenances and we will not be responsible for data loss or loss of compute hours.
+  * Infinite queues can run only on a subset of worker nodes (see ``info``) with a maximum walltime of 720 hours. Please note that jobs you run here are at your own risk. Jobs running on this partition can be killed without warning for system maintenance activities and we will not be responsible for data loss or loss of compute hours.
+
+
+.. _multi-node-jobs
+
+======================
+Multi-node Jobs
+======================
+
+Spider is designed for high throughput computing of large data sets (many terabytes to petabytes) and for independent jobs. It is therefore expected that each Slurm job on Spider fits within the capacity of a single worker node. For such regular jobs we advise to always only use 1 node per job script i.e., ``-N 1``. 
+
+If you need multi-node job execution, it may be worth to consider an HPC facility. If in doubt or if you require information about the HPC systems available at SURFsara then please contact ref:`our helpdesk <helpdesk>`.
+
 
 .. seealso:: Still need help? Contact :ref:`our helpdesk <helpdesk>`
 


### PR DESCRIPTION
To address issue 122 on makign the coupling between number of cpu cores, memory and scratch more explicit. Also to emphasize that users must use -c and not other options such as -N or -C.